### PR TITLE
Add checker for constraint adding

### DIFF
--- a/migration_checker/checks/__init__.py
+++ b/migration_checker/checks/__init__.py
@@ -3,6 +3,7 @@ from typing import Protocol
 from django.db.migrations import Migration
 from django.db.migrations.state import ProjectState
 
+from .add_constraint import check_add_constraint
 from .add_index import check_add_index
 from .add_non_nullable_field import check_add_non_nullable_field
 from .alter_multiple_tables import check_alter_multiple_tables
@@ -14,11 +15,14 @@ from .rename_model import check_rename_model
 
 
 class Check(Protocol):
-    def __call__(self, *, migration: Migration, state: ProjectState) -> list[str]:
+    def __call__(
+        self, *, migration: Migration, state: ProjectState, sql: str
+    ) -> list[str]:
         ...
 
 
 all_checks: list[Check] = [
+    check_add_constraint,
     check_add_index,
     check_add_non_nullable_field,
     check_alter_multiple_tables,

--- a/migration_checker/checks/add_constraint.py
+++ b/migration_checker/checks/add_constraint.py
@@ -1,0 +1,24 @@
+from django.db.migrations import Migration
+from django.db.migrations.state import ProjectState
+
+
+def check_add_constraint(
+    *, migration: Migration, state: ProjectState, sql: str
+) -> list[str]:
+    """
+    Warn if a constraint is being added without specifying NOT VALID
+    """
+
+    sql = sql.lower()
+    if "alter table" in sql and "add constraint" in sql and "not valid" not in sql:
+        return [
+            "⚠️ Adding constraint with immediate validation\n"
+            "This migration adds a constraint to an existing table without "
+            "specifying NOT VALID. This will cause an exclusive lock to be "
+            "held until the constraint has been checked on all rows. If the "
+            "table is large this can be problematic."
+        ]
+
+    # TODO: Check for unique or other types that create indexes
+
+    return []

--- a/migration_checker/checks/add_index.py
+++ b/migration_checker/checks/add_index.py
@@ -3,7 +3,9 @@ from django.db.migrations.operations import AddIndex
 from django.db.migrations.state import ProjectState
 
 
-def check_add_index(*, migration: Migration, state: ProjectState) -> list[str]:
+def check_add_index(
+    *, migration: Migration, state: ProjectState, sql: str
+) -> list[str]:
     warnings = []
 
     if any(isinstance(operation, AddIndex) for operation in migration.operations):

--- a/migration_checker/checks/add_non_nullable_field.py
+++ b/migration_checker/checks/add_non_nullable_field.py
@@ -4,7 +4,7 @@ from django.db.migrations.state import ProjectState
 
 
 def check_add_non_nullable_field(
-    *, migration: Migration, state: ProjectState
+    *, migration: Migration, state: ProjectState, sql: str
 ) -> list[str]:
     warnings = []
 

--- a/migration_checker/checks/alter_multiple_tables.py
+++ b/migration_checker/checks/alter_multiple_tables.py
@@ -5,7 +5,7 @@ from django.db.migrations.state import ProjectState
 
 
 def check_alter_multiple_tables(
-    *, migration: Migration, state: ProjectState
+    *, migration: Migration, state: ProjectState, sql: str
 ) -> list[str]:
     warnings = []
 

--- a/migration_checker/checks/atomic_run_python.py
+++ b/migration_checker/checks/atomic_run_python.py
@@ -3,7 +3,9 @@ from django.db.migrations.operations import RunPython
 from django.db.migrations.state import ProjectState
 
 
-def check_atomic_run_python(*, migration: Migration, state: ProjectState) -> list[str]:
+def check_atomic_run_python(
+    *, migration: Migration, state: ProjectState, sql: str
+) -> list[str]:
     warnings = []
 
     if migration.atomic and any(

--- a/migration_checker/checks/data_and_schema_changes.py
+++ b/migration_checker/checks/data_and_schema_changes.py
@@ -4,7 +4,7 @@ from django.db.migrations.state import ProjectState
 
 
 def check_data_and_schema_changes(
-    *, migration: Migration, state: ProjectState
+    *, migration: Migration, state: ProjectState, sql: str
 ) -> list[str]:
     warnings = []
 

--- a/migration_checker/checks/remove_field.py
+++ b/migration_checker/checks/remove_field.py
@@ -3,7 +3,9 @@ from django.db.migrations.operations import RemoveField
 from django.db.migrations.state import ProjectState
 
 
-def check_remove_field(*, migration: Migration, state: ProjectState) -> list[str]:
+def check_remove_field(
+    *, migration: Migration, state: ProjectState, sql: str
+) -> list[str]:
     warnings = []
 
     if any(isinstance(operation, RemoveField) for operation in migration.operations):

--- a/migration_checker/checks/rename_field.py
+++ b/migration_checker/checks/rename_field.py
@@ -3,7 +3,9 @@ from django.db.migrations.operations import RenameField
 from django.db.migrations.state import ProjectState
 
 
-def check_rename_field(*, migration: Migration, state: ProjectState) -> list[str]:
+def check_rename_field(
+    *, migration: Migration, state: ProjectState, sql: str
+) -> list[str]:
     warnings = []
 
     if any(isinstance(operation, RenameField) for operation in migration.operations):

--- a/migration_checker/checks/rename_model.py
+++ b/migration_checker/checks/rename_model.py
@@ -3,7 +3,9 @@ from django.db.migrations.operations import RenameModel
 from django.db.migrations.state import ProjectState
 
 
-def check_rename_model(*, migration: Migration, state: ProjectState) -> list[str]:
+def check_rename_model(
+    *, migration: Migration, state: ProjectState, sql: str
+) -> list[str]:
     warnings = []
 
     if any(isinstance(operation, RenameModel) for operation in migration.operations):

--- a/migration_checker/executor.py
+++ b/migration_checker/executor.py
@@ -79,11 +79,18 @@ class Executor:
         )
 
         for migration, _ in plan:
+            # Collect the SQL executed by this migration (if possible)
+            sql = "\n".join(
+                executor.loader.collect_sql(  # type: ignore[attr-defined]
+                    [(migration, False)]
+                )
+            )
+
             # Run checkers on the migration
             warnings = [
                 message
                 for check in all_checks
-                for message in check(migration=migration, state=state)
+                for message in check(migration=migration, state=state, sql=sql)
             ]
 
             if self.apply_migrations:


### PR DESCRIPTION
Adding a constraint to an existing table can be problematic if the table is large. This adds a checker that warns if a migration adds a constraint without specifying the NOT VALID clause.

Fixes #3