### PR TITLE
Add support for environments running psycopg3 to the migration executor

### DIFF
--- a/migration_checker/executor.py
+++ b/migration_checker/executor.py
@@ -33,7 +33,12 @@ class QueryLogger:
         context: dict[str, Any],
     ) -> Any:
         cursor = context["cursor"]
-        rendered_sql = cursor.mogrify(sql, params).decode()
+        mogrify_result = cursor.mogrify(sql, params)
+        rendered_sql: str = (
+            mogrify_result
+            if isinstance(mogrify_result, str)
+            else mogrify_result.decode()
+        )
         self.queries.append(rendered_sql)
 
         return execute(sql, params, many, context)


### PR DESCRIPTION
Is this too patchy? 

For context: https://kolonialno.slack.com/archives/C036G69PHPZ/p1713866272819579